### PR TITLE
Add NullSec Flipper Zero Suite - Comprehensive payload collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [`FalsePhilosophers Flipper BadUSB` Flipper zero community ducky payload repo.](https://github.com/FalsePhilosopher/badusb)
 - [`My-Flipper-Shits` Free and open-source \[BadUSB\] payloads for Flipper Zero.](https://github.com/aleff-github/my-flipper-shits/)
 - [`SerialHex2FlipperZeroInfrared` Convert IR serial messages into FlipperZero compatible IR files.](https://github.com/maehw/SerialHex2FlipperZeroInfrared)
+- [`NullSec Flipper Zero Suite` Comprehensive payload collection with 430+ files including BadUSB scripts, SubGHz captures, NFC tools, IR databases, and GPIO utilities for penetration testing.](https://github.com/bad-antics/nullsec-flipper-zero)
 
 ## Applications & Plugins
 - [`The Flipper Zero user interface editor` The GUI editor/generator for Flipper Zero.](https://ilin.pt/stuff/fui-editor/)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - [`FalsePhilosophers Flipper BadUSB` Flipper zero community ducky payload repo.](https://github.com/FalsePhilosopher/badusb)
 - [`My-Flipper-Shits` Free and open-source \[BadUSB\] payloads for Flipper Zero.](https://github.com/aleff-github/my-flipper-shits/)
 - [`SerialHex2FlipperZeroInfrared` Convert IR serial messages into FlipperZero compatible IR files.](https://github.com/maehw/SerialHex2FlipperZeroInfrared)
-- [`NullSec Flipper Zero Suite` Comprehensive payload collection with 430+ files including BadUSB scripts, SubGHz captures, NFC tools, IR databases, and GPIO utilities for penetration testing.](https://github.com/bad-antics/nullsec-flipper-zero)
+- [`NullSec Flipper Zero Suite` Comprehensive payload collection with 430+ files including BadUSB scripts, SubGHz captures, NFC tools, IR databases, and GPIO utilities for penetration testing.](https://github.com/bad-antics/nullsec-flipper-suite)
 
 ## Applications & Plugins
 - [`The Flipper Zero user interface editor` The GUI editor/generator for Flipper Zero.](https://ilin.pt/stuff/fui-editor/)


### PR DESCRIPTION
## Add NullSec Flipper Zero Suite

Adding [NullSec Flipper Zero Suite](https://github.com/bad-antics/nullsec-flipper-zero) to the **Databases & Dumps** section.

### What is NullSec Flipper Zero Suite?

A comprehensive payload collection with **430+ files** for the Flipper Zero, including:

- **BadUSB scripts** - Keystroke injection payloads for penetration testing
- **SubGHz captures** - Radio frequency captures and signal files
- **NFC tools** - NFC interaction and testing utilities
- **IR databases** - Infrared remote control databases
- **GPIO utilities** - Hardware interaction scripts

### Why this belongs in awesome-flipperzero

- Directly relevant to the Databases & Dumps section alongside other payload collections
- One of the largest community payload collections with 430+ files
- Covers all major Flipper Zero capabilities (BadUSB, SubGHz, NFC, IR, GPIO)
- Actively maintained and open source
- Follows the existing list entry format

The entry has been placed at the end of the Databases & Dumps section, following the established formatting convention.